### PR TITLE
Require minimum TLSv1.3

### DIFF
--- a/servers/https.go
+++ b/servers/https.go
@@ -32,6 +32,7 @@ func NewHttpsServer(conf *conf.Conf) *http.Server {
 			rateLimiter.ServeHTTP(rw, req)
 		}),
 		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				// error out on invalid domains
 				if !conf.Domains.IsValid(info.ServerName) {


### PR DESCRIPTION
Due to deprecation of TLSv1.0/1.1 and the old protocols supported by TLSv1.2, the new minimum HTTPS protocol requirement should be TLSv1.3.
