### PR TITLE
Require minimum TLSv1.2

### DIFF
--- a/servers/https.go
+++ b/servers/https.go
@@ -32,6 +32,16 @@ func NewHttpsServer(conf *conf.Conf) *http.Server {
 			rateLimiter.ServeHTTP(rw, req)
 		}),
 		TLSConfig: &tls.Config{
+			// Suggested by https://ssl-config.mozilla.org/#server=go&version=1.21.5&config=intermediate
+			MinVersion: tls.VersionTLS12,
+		        CipherSuites: []uint16{
+		            tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		            tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		            tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		            tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		            tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		            tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		        },
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				// error out on invalid domains
 				if !conf.Domains.IsValid(info.ServerName) {


### PR DESCRIPTION
Due to deprecation of TLSv1.0/1.1, the new minimum HTTPS protocol requirement should be TLSv1.3.

This specific SSL config has been generated to disable the use of deprecated protocols being supported by TLSv1.2.
